### PR TITLE
优化插件的出图速度

### DIFF
--- a/src/main/kotlin/ApexResponseMap.kt
+++ b/src/main/kotlin/ApexResponseMap.kt
@@ -138,6 +138,7 @@ data class NextXXX(
 )
 
 data class CurrentXXXX(
+    val code: String,
     val asset: String,
     val map: String
 )

--- a/src/main/kotlin/ApexUtils.kt
+++ b/src/main/kotlin/ApexUtils.kt
@@ -1,0 +1,30 @@
+package pers.shennoter
+
+import java.awt.image.BufferedImage
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.net.URL
+import javax.imageio.ImageIO
+
+class ApexImage {
+    var isEmpty = true
+    private val image = ByteArrayOutputStream()
+    fun save(buffImage: BufferedImage) {
+        ImageIO.write(buffImage, "png", image)
+        isEmpty = false
+    }
+
+    fun get(): ByteArrayInputStream {
+        return (ByteArrayInputStream(image.toByteArray()))
+    }
+}
+
+fun ImageCache(name: String, url: String): BufferedImage {
+    val file = File("./data/pers.shennoter.ranklookup/$name.png")
+    if (!file.exists()) {
+        val image: BufferedImage = ImageIO.read(URL(url))
+        ImageIO.write(image, "png", File("./data/pers.shennoter.ranklookup/$name.png"))
+    }
+    return ImageIO.read(File("./data/pers.shennoter.ranklookup/$name.png"))
+}

--- a/src/main/kotlin/ApexUtils.kt
+++ b/src/main/kotlin/ApexUtils.kt
@@ -11,7 +11,7 @@ class ApexImage {
     var isEmpty = true
     private val image = ByteArrayOutputStream()
     fun save(buffImage: BufferedImage) {
-        ImageIO.write(buffImage, "png", image)
+        ImageIO.write(buffImage, Config.picType, image)
         isEmpty = false
     }
 

--- a/src/main/kotlin/Config.kt
+++ b/src/main/kotlin/Config.kt
@@ -9,4 +9,6 @@ object Config : AutoSavePluginConfig("config") {
     val ApiKey: String by value("")
     @ValueDescription("回复模式: pic为图片，text为文字(只适用于玩家信息和地图轮换)")
     var mode: String by value("pic")
+    @ValueDescription("图片质量: PNG原图，JPG更小")
+    var picType: String by value("PNG")
 }

--- a/src/main/kotlin/CraftStat.kt
+++ b/src/main/kotlin/CraftStat.kt
@@ -1,8 +1,5 @@
 import com.google.gson.Gson
-import pers.shennoter.ApexImage
-import pers.shennoter.ApexResponseCraft
-import pers.shennoter.Config
-import pers.shennoter.RankLookUp
+import pers.shennoter.*
 import java.awt.image.BufferedImage
 import java.net.URL
 import javax.imageio.ImageIO
@@ -25,10 +22,10 @@ fun craftStat(image: ApexImage):String{
     }
 
     val res = Gson().fromJson(requestStr, ApexResponseCraft::class.java)
-    val daily1: BufferedImage = ImageIO.read(URL(res[0].bundleContent[0].itemType.asset))
-    val daily2: BufferedImage = ImageIO.read(URL(res[0].bundleContent[1].itemType.asset))
-    val weekly1: BufferedImage = ImageIO.read(URL(res[1].bundleContent[0].itemType.asset))
-    val weekly2: BufferedImage = ImageIO.read(URL(res[1].bundleContent[1].itemType.asset))
+    val daily1: BufferedImage = ImageCache("craft_"+res[0].bundleContent[0].itemType.name,res[0].bundleContent[0].itemType.asset)
+    val daily2: BufferedImage = ImageCache("craft_"+res[0].bundleContent[1].itemType.name,res[0].bundleContent[1].itemType.asset)
+    val weekly1: BufferedImage = ImageCache("craft_"+res[1].bundleContent[0].itemType.name,res[1].bundleContent[0].itemType.asset)
+    val weekly2: BufferedImage = ImageCache("craft_"+res[1].bundleContent[1].itemType.name,res[1].bundleContent[1].itemType.asset)
     val img1: BufferedImage = mergeImage(true, daily1, daily2)
     val img2: BufferedImage = mergeImage(true, weekly1, weekly2)
     val img = mergeImage(false, img1, img2)

--- a/src/main/kotlin/CraftStat.kt
+++ b/src/main/kotlin/CraftStat.kt
@@ -1,13 +1,14 @@
 import com.google.gson.Gson
+import pers.shennoter.ApexImage
+import pers.shennoter.ApexResponseCraft
 import pers.shennoter.Config
 import pers.shennoter.RankLookUp
 import java.awt.image.BufferedImage
-import java.io.File
 import java.net.URL
 import javax.imageio.ImageIO
 
 
-fun craftStat():String{
+fun craftStat(image: ApexImage):String{
     if(Config.ApiKey == "") {
         return "未填写ApiKey"
     }
@@ -31,7 +32,7 @@ fun craftStat():String{
     val img1: BufferedImage = mergeImage(true, daily1, daily2)
     val img2: BufferedImage = mergeImage(true, weekly1, weekly2)
     val img = mergeImage(false, img1, img2)
-    ImageIO.write(img,"png", File("./data/pers.shennoter.ranklookup/craft.png"))
+    image.save(img)
     return code
 }
 

--- a/src/main/kotlin/MapStat.kt
+++ b/src/main/kotlin/MapStat.kt
@@ -42,11 +42,11 @@ fun mapStat(image: ApexImage):String{
 }
 
 fun mapPictureMode(res: ApexResponseMap, image: ApexImage){
-    val buffer:BufferedImage = ImageIO.read(URL("https://apexlegendsstatus.com/assets/maps/Arena_Encore.png"))
-    val battleRoyale: BufferedImage = ImageIO.read(URL(res.battle_royale.current.asset))
-    val ranked:BufferedImage = ImageIO.read(URL(res.ranked.current.asset))
-    val arenas: BufferedImage = ImageIO.read(URL(res.arenas.current.asset))
-    val arenasRanked: BufferedImage = ImageIO.read(URL(res.arenasRanked.current.asset))
+    val buffer:BufferedImage = ImageCache("buffer","https://apexlegendsstatus.com/assets/maps/Arena_Encore.png")
+    val battleRoyale: BufferedImage = ImageCache("mapbr_"+res.battle_royale.current.code,res.battle_royale.current.asset)
+    val ranked:BufferedImage = ImageCache("mapbr_"+res.ranked.current.code,res.ranked.current.asset)
+    val arenas: BufferedImage = ImageCache("mapar_"+res.arenas.current.code,res.arenas.current.asset)
+    val arenasRanked: BufferedImage = ImageCache("mapar_"+res.arenasRanked.current.code,res.arenasRanked.current.asset)
     //val control:BufferedImage = ImageIO.read(URL(res.control.current.asset))
 
     //渲染背景

--- a/src/main/kotlin/MapStat.kt
+++ b/src/main/kotlin/MapStat.kt
@@ -11,7 +11,7 @@ import java.net.URL
 import javax.imageio.ImageIO
 
 
-fun mapStat():String{
+fun mapStat(image: ApexImage):String{
     if(Config.ApiKey == "") {
         return "未填写ApiKey"
     }
@@ -31,7 +31,7 @@ fun mapStat():String{
 
 
     if (Config.mode == "pic"){
-        mapPictureMode(res)
+        mapPictureMode(res, image)
     }
     else{
         textinfo = mapTextMode(res)
@@ -41,7 +41,7 @@ fun mapStat():String{
     return code
 }
 
-fun mapPictureMode(res: ApexResponseMap){
+fun mapPictureMode(res: ApexResponseMap, image: ApexImage){
     val buffer:BufferedImage = ImageIO.read(URL("https://apexlegendsstatus.com/assets/maps/Arena_Encore.png"))
     val battleRoyale: BufferedImage = ImageIO.read(URL(res.battle_royale.current.asset))
     val ranked:BufferedImage = ImageIO.read(URL(res.ranked.current.asset))
@@ -76,7 +76,7 @@ fun mapPictureMode(res: ApexResponseMap){
     img = drawTextToImage(img,"剩余时间："+"${res.arenasRanked.current.remainingTimer}",90,2250,35, Color.white)
     img = drawTextToImage(img,"下一轮换："+"${res.arenasRanked.next.map}",90,2300,35, Color.white)
 
-    ImageIO.write(img,"png", File("./data/pers.shennoter.ranklookup/map.png"))
+    image.save(img)
 }
 
 fun mapTextMode(res:ApexResponseMap):String{

--- a/src/main/kotlin/PlayerStat.kt
+++ b/src/main/kotlin/PlayerStat.kt
@@ -1,4 +1,5 @@
 import com.google.gson.Gson
+import pers.shennoter.ApexImage
 import pers.shennoter.ApexResponseError
 import pers.shennoter.Config
 import pers.shennoter.RankLookUp
@@ -10,7 +11,7 @@ import java.net.URL
 import javax.imageio.ImageIO
 
 
-fun playerStat(playerid: String): String{
+fun playerStat(playerid: String,image: ApexImage): String{
     if(Config.ApiKey == "") {
         return "未填写ApiKey"
     }
@@ -45,7 +46,7 @@ fun playerStat(playerid: String): String{
     var textinfo = ""
     val res = Gson().fromJson(requestStr, ApexResponsePlayer::class.java)
     if (Config.mode == "pic"){
-        playerPicturMode(res,playerid)
+        playerPicturMode(res,playerid,image)
     }
     else{
         textinfo = playerTextMode(res,playerid)
@@ -88,7 +89,7 @@ fun drawImageToImage(img1: BufferedImage,
     return img1
 }
 
-fun playerPicturMode(res:ApexResponsePlayer,playerid : String){
+fun playerPicturMode(res:ApexResponsePlayer,playerid : String,image : ApexImage){
     val file = File("./data/pers.shennoter.ranklookup/apex.png")
     if(!file.exists()){
         val background: BufferedImage = ImageIO.read(URL("https://shennoter.top/wp-content/uploads/mirai/apex.png"))
@@ -175,7 +176,7 @@ fun playerPicturMode(res:ApexResponsePlayer,playerid : String){
     img = drawTextToImage(img,status, 1720,1860,50,Color.white)
 
     //创建图片
-    ImageIO.write(img,"png", File("./data/pers.shennoter.ranklookup/player.png"))
+    image.save(img)
 }
 
 fun playerTextMode(res:ApexResponsePlayer,playerid : String):String{

--- a/src/main/kotlin/PlayerStat.kt
+++ b/src/main/kotlin/PlayerStat.kt
@@ -1,8 +1,5 @@
 import com.google.gson.Gson
-import pers.shennoter.ApexImage
-import pers.shennoter.ApexResponseError
-import pers.shennoter.Config
-import pers.shennoter.RankLookUp
+import pers.shennoter.*
 import java.awt.*
 import java.awt.image.BufferedImage
 import java.io.File
@@ -90,15 +87,10 @@ fun drawImageToImage(img1: BufferedImage,
 }
 
 fun playerPicturMode(res:ApexResponsePlayer,playerid : String,image : ApexImage){
-    val file = File("./data/pers.shennoter.ranklookup/apex.png")
-    if(!file.exists()){
-        val background: BufferedImage = ImageIO.read(URL("https://shennoter.top/wp-content/uploads/mirai/apex.png"))
-        ImageIO.write(background,"png", File("./data/pers.shennoter.ranklookup/apex.png"))
-    }
-    val background: BufferedImage = ImageIO.read(File("./data/pers.shennoter.ranklookup/apex.png"))
-    val rank: BufferedImage = ImageIO.read(URL(res.global.rank.rankImg))
-    val arena: BufferedImage = ImageIO.read(URL(res.global.arena.rankImg))
-    val legend: BufferedImage = ImageIO.read(URL(res.legends.selected.ImgAssets.banner))
+    val background: BufferedImage = ImageCache("apex","https://shennoter.top/wp-content/uploads/mirai/apex.png")
+    val rank: BufferedImage = ImageCache("rank_"+res.global.rank.rankName,res.global.rank.rankImg)
+    val arena: BufferedImage = ImageCache("arena_"+res.global.arena.rankName,res.global.arena.rankImg)
+    val legend: BufferedImage = ImageCache("legend_"+res.legends.selected.LegendName,res.legends.selected.ImgAssets.banner)
     var name = res.global.name
     if (name == ""){
         name = playerid

--- a/src/main/kotlin/RankLookUp.kt
+++ b/src/main/kotlin/RankLookUp.kt
@@ -7,26 +7,11 @@ import net.mamoe.mirai.console.command.BuiltInCommands.AutoLoginCommand.clear
 import net.mamoe.mirai.console.command.BuiltInCommands.AutoLoginCommand.setConfig
 import net.mamoe.mirai.console.plugin.jvm.JvmPluginDescription
 import net.mamoe.mirai.console.plugin.jvm.KotlinPlugin
+
 import net.mamoe.mirai.contact.Contact.Companion.sendImage
+import pers.shennoter.RankLookUp.reload
 import playerStat
-import java.awt.image.BufferedImage
-import java.io.ByteArrayInputStream
-import java.io.ByteArrayOutputStream
 import java.io.File
-import javax.imageio.ImageIO
-
-class ApexImage {
-    var isEmpty = true
-    private val image = ByteArrayOutputStream()
-    fun save(buffImage: BufferedImage) {
-        ImageIO.write(buffImage, "png", image)
-        isEmpty = false
-    }
-
-    fun get(): ByteArrayInputStream {
-        return (ByteArrayInputStream(image.toByteArray()))
-    }
-}
 
 object RankLookUp : KotlinPlugin(
     JvmPluginDescription(

--- a/src/main/kotlin/RankLookUp.kt
+++ b/src/main/kotlin/RankLookUp.kt
@@ -7,11 +7,26 @@ import net.mamoe.mirai.console.command.BuiltInCommands.AutoLoginCommand.clear
 import net.mamoe.mirai.console.command.BuiltInCommands.AutoLoginCommand.setConfig
 import net.mamoe.mirai.console.plugin.jvm.JvmPluginDescription
 import net.mamoe.mirai.console.plugin.jvm.KotlinPlugin
-
 import net.mamoe.mirai.contact.Contact.Companion.sendImage
-import pers.shennoter.RankLookUp.reload
 import playerStat
+import java.awt.image.BufferedImage
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 import java.io.File
+import javax.imageio.ImageIO
+
+class ApexImage {
+    var isEmpty = true
+    private val image = ByteArrayOutputStream()
+    fun save(buffImage: BufferedImage) {
+        ImageIO.write(buffImage, "png", image)
+        isEmpty = false
+    }
+
+    fun get(): ByteArrayInputStream {
+        return (ByteArrayInputStream(image.toByteArray()))
+    }
+}
 
 object RankLookUp : KotlinPlugin(
     JvmPluginDescription(
@@ -43,12 +58,13 @@ object Player : SimpleCommand(
 ) {
     @Handler
     suspend fun CommandSender.apexPlayerInfo(id: String) {
-        val code = playerStat(id)
+        val image = ApexImage()
+        val code = playerStat(id,image)
         when(Config.mode){
             "pic"-> {
                 if (code == "查询成功") {
                     try {
-                        subject?.sendImage(File("./data/pers.shennoter.ranklookup/player.png"))
+                        subject?.sendImage(image.get())
                     } catch (e: Exception) {
                         RankLookUp.logger.error("图片读取出错")
                     }
@@ -72,12 +88,13 @@ object Map : SimpleCommand(
 ){
     @Handler
     suspend fun CommandSender.apexMapInfo() {
-        val code = mapStat()
+        val image = ApexImage()
+        val code = mapStat(image)
         when(Config.mode){
             "pic"-> {
                 if (code == "查询成功") {
                     try {
-                        subject?.sendImage(File("./data/pers.shennoter.ranklookup/map.png"))
+                        subject?.sendImage(image.get())
                     } catch (e: Exception) {
                         RankLookUp.logger.error("图片读取出错")
                     }
@@ -101,10 +118,11 @@ object Craft : SimpleCommand(
 ){
     @Handler
     suspend fun CommandSender.apexCraftInfo() {
-        val code = craftStat()
+        val image = ApexImage()
+        val code = craftStat(image)
         if (code == "查询成功") {
             try {
-                subject?.sendImage(File("./data/pers.shennoter.ranklookup/craft.png"))
+                subject?.sendImage(image.get())
             } catch (e: Exception) {
                 RankLookUp.logger.error("图片读取出错")
             }


### PR DESCRIPTION
### 修改内容如下

**1.优化出图方式**
增加了一个`ApexImage`类用于在内存中储存制作好的图片。原方法会增加硬盘的IO压力，同时在多条指令同时运行时会有读写冲突的可能性，因此可以选择将制作的图片储存于内存之中来优化出图的方式。

**2.将所有源图片进行缓存**
增加了一个`ImageCache`类用于对图片源缓存。图片源来自Cloudflare，而CF的访问速度挤满，通常下行速度可低至2mbps，缓存所有图片可以减少下载图片的时间，而这些原图片并没有必要每一次都进行下载。缓存文件均保存在插件的data目录下，后续可考虑一个清除所有缓存的指令来避免未来可能发生的缓存错误。

**3.对ImageIO提供可选的JPG输出选项**
插件出图分辨率已足够清晰，使用PNG的无损格式会导致图片高达10mb，不利于机器人在服务器上上传图片和用户在客户端的下载和阅读，使用JPG格式可以保持足够的清晰度并将图片压缩至1mb以下。

PR尽可能没有干涉项目其他无关的代码，并经过测试功能与原来无异。可以将出图的速度大幅增加（特别是相同内容多次询问的
出图速度），一个可用的测试包：https://github.com/EvolvedGhost/ApexRankLookUp/releases/tag/V1.1.1